### PR TITLE
Use adaptive k-sampling in full solve command

### DIFF
--- a/src/SymBoltz.jl
+++ b/src/SymBoltz.jl
@@ -43,7 +43,7 @@ include("plot.jl")
 
 export RMΛ, ΛCDM, w0waCDM, QCDM, GRΛCDM, BDΛCDM
 export CosmologyProblem, CosmologySolution
-export solve, solvebg, solvept, remake, issuccess, parameter_updater
+export solve, solvebg, solvept, solvept_adaptive, remake, issuccess, parameter_updater
 export parameters_Planck18
 export spectrum_primordial, spectrum_matter, spectrum_matter_nonlinear, spectrum_cmb, correlation_function, variance_matter, stddev_matter, los_integrate, source_grid, source_grid_adaptive, sound_horizon, SphericalBesselCache
 export express_derivatives

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -458,3 +458,10 @@ end
     DlTT = spectrum_cmb(:TT, prob, jl; normalization = :Dl)
     DlEE = spectrum_cmb(:EE, prob, jl; normalization = :Dl)
 end
+
+@testset "Adaptive k-solving" begin
+    bgsol = solvebg(prob.bg)
+    ks = [1.0, 1000.0]
+    Ss = :Φ
+    ks, ptsols = solvept_adaptive(prob.pt, bgsol, ks, prob.bgspline, Ss; rtol = 1e-1);
+end


### PR DESCRIPTION
```julia
using SymBoltz, Plots
M = ΛCDM(K = nothing) # flat
pars = SymBoltz.parameters_Planck18(M)
prob = CosmologyProblem(M, pars)

ks = [1.0, 2000.0]
@time sol = solve(prob, ks; adaptiveopts = (rtol = 1e-3,))
```
```julia
τs = sol[M.τ]
Ss = sol(M.ST0, τs, sol.ks)
surface(sol.ks, τs, Ss; ylims = (0.03, 0.08), title = "$(length(sol.ks)) ks")
```
<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/cb740de8-231d-4d73-8add-00ee6a5b2046" />

```julia
plot(sol.ks, eachindex(sol.ks); marker = :circle, label = nothing)
```
<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/f768f90c-5bec-4f82-ba10-d83620b3e77e" />
