### PR TITLE
Support SciMLBase v3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SymBoltz"
 uuid = "64c5a815-d72d-4982-8b1f-85a778bbef4e"
-version = "1.4.0"
+version = "1.4.1"
 authors = ["Herman Sletmoen"]
 
 [deps]
@@ -73,7 +73,7 @@ QuadGK = "2.11.1"
 RecipesBase = "1.3.4"
 RecursiveFactorization = "0.2.23"
 Reexport = "1.2.2"
-SciMLBase = "2.72.2"
+SciMLBase = "2.72.2, 3.1"
 SciMLStructures = "1.7.0"
 Setfield = "1.1.1"
 SparseArrays = "1.10.0"


### PR DESCRIPTION
## Summary

Courtesy PR for the SciMLBase v3 release.

- Extend `SciMLBase` compat to `"2.72.2, 3.1"` (keep existing lower bound).
- Bump `SymBoltz` version to 1.4.1.

No code changes required — a grep of `src/` and `test/` found no references to the SciMLBase v3 breaking surface (`u_modified!`, removed `DEProblem` type alias, 3-arg ensemble `prob_func`, or single-int timeseries `sol[i]` indexing whose semantics changed on non-scalar ODEs). Existing solution indexing is symbolic (`sol[M.x]` style via SymbolicIndexingInterface), which is unaffected by the v3 changes.

## Known limitations

- **Env resolution will fail** at the `Pkg.add` step on CI: SciMLBase 3.1 requires `RecursiveArrayTools` v4, but `OrdinaryDiffEq` in the registry still pins RAT ≤ 3.54. This blocks the whole ecosystem until OrdinaryDiffEq releases a RAT-v4-compatible version — not fixable here.
- **ModelingToolkit compat**: SymBoltz pins `ModelingToolkit = "11.0.0"`. Whether MTK 11 supports SciMLBase v3 needs review; if it doesn't, the v3 range in this PR is effectively unreachable in practice until MTK bumps. Consider tightening or dropping v3 from compat until MTK is verified.

## Context

Part of a courtesy sweep across SciMLBase v3 reverse dependencies. SciMLBase v3 release notes: https://github.com/SciML/SciMLBase.jl/releases/tag/v3.0.0.

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)