### PR TITLE
Minor fixes and adjustments to CMB computation

### DIFF
--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -45,12 +45,12 @@ pars = Dict(
     M.I.ln_As1e10 => 3.0,
     M.I.ns => 0.95
 )
-ks = 10 .^ range(-5, 1, length=500) / u"Mpc"
 prob = CosmologyProblem(M, pars)
 ```
 Finally, we can simply solve the problem:
 
 ```@example getting_started
+ks = 10 .^ range(-5, 1, length=500) / u"Mpc"
 sol = solve(prob, ks) # or just solve(prob) to solve only the background
 ```
 
@@ -83,8 +83,7 @@ Similarly, to get $\Phi(k,τ)$ for the 500 wavenumbers we solved for at the same
 You could plot this with `using Plots; plot(log10.(as), transpose(Φs))`, but this is more convenient with the included plot recipe:
 ```@example getting_started
 using Plots
-ks_plot = [1e-3, 1e-2, 1e-1, 1e-0] / u"Mpc"
-plot(sol, log10(M.g.a), M.g.Φ, ks_plot) # lg(a) vs. Φ for 4 wavenumbers
+plot(sol, log10(M.g.a), M.g.Φ, [1e-3, 1e-2, 1e-1, 1e-0] / u"Mpc") # lg(a) vs. Φ for 4 wavenumbers
 ```
 
 We can also calculate the matter power spectrum:
@@ -109,7 +108,7 @@ plot!(p[3], sol, log10(M.g.a), log10(M.g.H))
 plot!(p[4], sol, log10(M.g.a), [M.b.rec.XHe⁺⁺, M.b.rec.XHe⁺, M.b.rec.XH⁺, M.b.Xe])
 plot!(p[5], sol, log10(M.g.a), log10.([M.γ.T, M.b.T] ./ M.γ.T₀))
 plot!(p[6], sol, log10(M.g.a), log10(abs(M.b.κ)))
-plot!(p[7], sol, log10(M.g.a), [M.g.Φ, M.g.Ψ], ks_plot)
-plot!(p[8], sol, log10(M.g.a), log10.(abs.([M.b.δ, M.c.δ, M.γ.δ, M.ν.δ, M.h.δ])), ks_plot; klabel = false)
-plot!(p[9], sol, log10(M.g.a), log10.(abs.([M.b.θ, M.c.θ, M.γ.θ, M.ν.θ, M.h.θ])), ks_plot; klabel = false)
+plot!(p[7], sol, log10(M.g.a), [M.g.Φ, M.g.Ψ], 1e-1 / u"Mpc")
+plot!(p[8], sol, log10(M.g.a), log10.(abs.([M.b.δ, M.c.δ, M.γ.δ, M.ν.δ, M.h.δ])), 1e-1 / u"Mpc"; klabel = false)
+plot!(p[9], sol, log10(M.g.a), log10.(abs.([M.b.θ, M.c.θ, M.γ.θ, M.ν.θ, M.h.θ])), 1e-1 / u"Mpc"; klabel = false)
 ```

--- a/src/observables/angular.jl
+++ b/src/observables/angular.jl
@@ -31,14 +31,15 @@ function SphericalBesselCache(ls::AbstractVector; xmax = 10*ls[end], dx = 2π/48
 end
 
 # TODO: define chain rule like in https://github.com/JuliaDiff/ForwardDiff.jl/blob/master/src/dual.jl?
-function (jl::SphericalBesselCache)(l, x)
+@fastmath function (jl::SphericalBesselCache)(l, x)
     il = jl.i[l]
     ix₋ = 1+trunc(Int, x*jl.invdx) # faster than searchsortedfirst(jl.x, x)
     ix₊ = min(ix₋ + 1, length(jl.x))
     x₋ = jl.x[ix₋]
     y₋ = jl.y[ix₋, il]
     y₊ = jl.y[ix₊, il]
-    return y₋ + (y₊ - y₋) * (x - x₋) * jl.invdx
+    w = (x - x₋) * jl.invdx
+    return muladd(w, y₊ - y₋, y₋) # i.e. y₋ + (y₊ - y₋) * (x - x₋) * jl.invdx
 end
 
 # Out-of-place spherical Bessel function variants

--- a/src/observables/angular.jl
+++ b/src/observables/angular.jl
@@ -208,7 +208,7 @@ function spectrum_cmb(ΘlAs::AbstractMatrix, ΘlBs::AbstractMatrix, P0s::Abstrac
 end
 
 """
-    spectrum_cmb(modes::AbstractVector{<:Symbol}, prob::CosmologyProblem, jl::SphericalBesselCache; normalization = :Cl, unit = nothing, kτ0s = 0.1*jl.l[begin]:2π/2:10*jl.l[end], xs = 0.0:0.0008:1.0, l_limber = 50, integrator = TrapezoidalRule(), bgopts = (alg = Rodas5P(), reltol = 1e-7, abstol = 1e-7), ptopts = (alg = Rodas5P(), reltol = 1e-5, abstol = 1e-5), sourceopts = (rtol = 1e-3, atol = 0.9), coarse_length = 9, thread = true, verbose = false, kwargs...)
+    spectrum_cmb(modes::AbstractVector{<:Symbol}, prob::CosmologyProblem, jl::SphericalBesselCache; normalization = :Cl, unit = nothing, kτ0s = 0.1*jl.l[begin]:2π/2:10*jl.l[end], xs = 0.0:0.0008:1.0, l_limber = 50, integrator = TrapezoidalRule(), bgopts = (alg = bgalg(prob), reltol = 1e-7, abstol = 1e-7), ptopts = (alg = ptalg(prob),, reltol = 1e-5, abstol = 1e-5), sourceopts = (rtol = 1e-3, atol = 0.9), coarse_length = 9, thread = true, verbose = false, kwargs...)
 
 Compute angular CMB power spectra ``Cₗᴬᴮ`` at angular wavenumbers `ls` from the cosmological problem `prob`.
 The requested `modes` are specified as a vector of symbols in the form `:AB`, where `A` and `B` are `T` (temperature), `E` (E-mode polarization) or `ψ` (lensing).
@@ -234,7 +234,7 @@ modes = [:TT, :TE, :ψψ, :ψT]
 Dls = spectrum_cmb(modes, prob, jl; normalization = :Dl, unit = u"μK")
 ```
 """
-function spectrum_cmb(modes::AbstractVector{<:Symbol}, prob::CosmologyProblem, jl::SphericalBesselCache; normalization = :Cl, unit = nothing, kτ0s = 0.1*jl.l[begin]:2π/2:10*jl.l[end], xs = 0.0:0.0008:1.0, l_limber = 50, integrator = TrapezoidalRule(), bgopts = (alg = Rodas5P(), reltol = 1e-7, abstol = 1e-7), ptopts = (alg = Rodas5P(), reltol = 1e-5, abstol = 1e-5), sourceopts = (rtol = 1e-3, atol = 0.9), coarse_length = 9, thread = true, verbose = false, kwargs...)
+function spectrum_cmb(modes::AbstractVector{<:Symbol}, prob::CosmologyProblem, jl::SphericalBesselCache; normalization = :Cl, unit = nothing, kτ0s = 0.1*jl.l[begin]:2π/2:10*jl.l[end], xs = 0.0:0.0008:1.0, l_limber = 50, integrator = TrapezoidalRule(), bgopts = (alg = bgalg(prob), reltol = 1e-7, abstol = 1e-7), ptopts = (alg = ptalg(prob), reltol = 1e-5, abstol = 1e-5), sourceopts = (rtol = 1e-3, atol = 0.9), coarse_length = 9, thread = true, verbose = false, kwargs...)
     ls = jl.l
     sol = solve(prob; bgopts, verbose)
     τ0 = getsym(sol, prob.M.τ0)(sol)

--- a/src/observables/fourier.jl
+++ b/src/observables/fourier.jl
@@ -223,7 +223,9 @@ Conformal times are unchanged.
 function source_grid(Ss_coarse::AbstractArray, ks_coarse, ks_fine; ktransform = identity, thread = true)
     size_coarse = size(Ss_coarse)
     size_fine = (size_coarse[1], size_coarse[2], length(ks_fine))
-    Ns, Nτ, _ = size(Ss_coarse)
+    Ns, Nτ, Nk = size(Ss_coarse)
+
+    Nk == length(ks_coarse) || error("Length of coarse k-grid does not match source array")
 
     Ss_fine = similar(Ss_coarse, size_fine)
     xs_coarse = ktransform.(ks_coarse) # TODO: user should just pass different ks as input instead


### PR DESCRIPTION
Using just `ptalg = Rodas5P()` was causing it to use the subpar UMFPACK algorithm for sparse Jacobians instead of KLU. Changing to `ptalg(prob)` fixes this.