### PR TITLE
Stabilize initial conditions with high lmax

### DIFF
--- a/docs/src/plot.md
+++ b/docs/src/plot.md
@@ -38,7 +38,7 @@ Visualize the CMB source function $S₀(k,τ)$ in a 3D plot:
 ```@example plot
 using CairoMakie
 τs = range(0.05, 0.08; length=50)
-ks = range(0.0, 0.3, length=100) / u"Mpc"
+ks = range(0.0, 0.3, length=100)[2:end] / u"Mpc"
 sol = solve(prob, ks)
 
 xs = τs
@@ -46,7 +46,7 @@ ys = ks*u"Mpc"
 zs = sol(M.ST, τs, ks)
 
 fig = Figure()
-ax = Axis3(fig[1,1], azimuth = π/4, xlabel = "k/Mpc⁻¹", ylabel = "τ/H₀⁻¹", zlabel = "S₀(τ,k)")
+ax = Axis3(fig[1,1], azimuth = π/4, xlabel = "τ/H₀⁻¹", ylabel = "k/Mpc⁻¹", zlabel = "S₀(τ,k)")
 cmax = min(-minimum(filter(!isnan, zs)), maximum(filter(!isnan, zs))) # saturate both ends of color scale
 surface!(ax, xs, ys, zs; alpha = 0.9, colormap = :seismic, colorrange = (-cmax, +cmax))
 

--- a/src/models/neutrinos.jl
+++ b/src/models/neutrinos.jl
@@ -34,7 +34,8 @@ function massless_neutrinos(g; lmax = 10, name = :ν, kwargs...)
         δ ~ -2 * g.Ψ # adiabatic: δᵢ/(1+wᵢ) == δⱼ/(1+wⱼ) (https://cmb.wintherscoming.no/theory_initial.php#adiabatic)
         θ ~ 1//2 * (k^2*τ) * g.Ψ
         σ ~ 1//15 * (k*τ)^2 * g.Ψ
-        [F[l] ~ +l/(2l+1) * k*τ * F[l-1] for l in 3:lmax]...
+        F[3] ~ +3//(2*3+1) * k*τ * F[2] # l/(2l+1) * k*τ * F[l-1] → 0 quickly
+        [F[l] ~ 0 for l in 4:lmax]...
     ]
     description = "Massless neutrinos"
     return extend(ν, System(eqs, τ, vars, pars; initialization_eqs = ieqs, name, kwargs...); description)

--- a/src/models/photons.jl
+++ b/src/models/photons.jl
@@ -29,7 +29,7 @@ function photons(g; polarization = true, lmax = 10, name = :γ, kwargs...)
         # Bertschinger & Ma (64) with anₑσₜ -> -κ̇
         D(F0) ~ -k*F[1] + 4*D(g.Φ)
         D(F[1]) ~ k/3*(F0-2*F[2]+4*g.Ψ) - 4//3 * κ̇/k * (θb - θ) # D(θ) ~ -κ̇ (θb-θγ)
-        [D(F[l]) ~ k/(2l+1) * (l*F[l-1] - (l+1)*F[l+1]) + κ̇ * (F[l] - δkron(l,2)//10*Π) for l in 2:lmax-1]...
+        [D(F[l]) ~ k/(2l+1) * (l*F[l-1] - (l+1)*F[l+1]) + κ̇ * (F[l] - δkron(l,2)*Π/10) for l in 2:lmax-1]...
         D(F[lmax]) ~ k*F[lmax-1] - (lmax+1) / τ * F[lmax] + κ̇ * F[lmax] # τ ≈ 1/ℋ
         δ ~ F0
         Δ ~ δ + 3*g.ℋ*(1+γ.w)*θ/k^2
@@ -48,20 +48,22 @@ function photons(g; polarization = true, lmax = 10, name = :γ, kwargs...)
         F0 ~ -2*g.Ψ # Dodelson (7.89) # TODO: derive automatically
         F[1] ~ 2//3 * k*τ*g.Ψ # Dodelson (7.95)
         F[2] ~ (polarization ? -8//15 : -20//45) * k/κ̇ * F[1] # depends on whether polarization is included
-        [F[l] ~ -l/(2l+1) * k/κ̇ * F[l-1] for l in 3:lmax]...
+        F[3] ~ -3//(2*3+1) * k/κ̇ * F[2] # -l/(2l+1) * k/κ̇ * F[l-1] → 0 quickly
+        [F[l] ~ 0 for l in 4:lmax]...
     ]
     if polarization
         append!(eqs, [
             D(G0) ~ k * (-G[1]) + κ̇ * (G0 - Π/2)
             D(G[1]) ~ k/(2*1+1) * (1*G0 - 2*G[2]) + κ̇ * G[1]
-            [D(G[l]) ~ k/(2l+1) * (l*G[l-1] - (l+1)*G[l+1]) + κ̇ * (G[l] - δkron(l,2)//10*Π) for l in 2:lmax-1]...
+            [D(G[l]) ~ k/(2l+1) * (l*G[l-1] - (l+1)*G[l+1]) + κ̇ * (G[l] - δkron(l,2)*Π/10) for l in 2:lmax-1]...
             D(G[lmax]) ~ k*G[lmax-1] - (lmax+1) / τ * G[lmax] + κ̇ * G[lmax]
         ])
         append!(ieqs, [
-            G0 ~ 5//16 * F[2],
-            G[1] ~ -1//16 * k/κ̇ * F[2],
-            G[2] ~ 1//16 * F[2],
-            [G[l] ~ -l/(2l+1) * k/κ̇ * G[l-1] for l in 3:lmax]...
+            G0 ~ 5//16 * F[2]
+            G[1] ~ -1//16 * k/κ̇ * F[2]
+            G[2] ~ 1//16 * F[2]
+            G[3] ~ -3//(2*3+1) * k/κ̇ * G[2] # -l/(2l+1) * k/κ̇ * G[l-1] → 0 quickly
+            [G[l] ~ 0 for l in 4:lmax]...
         ])
     else
         append!(eqs, [collect(G .~ 0)...]) # pin to zero

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -717,3 +717,9 @@ end
     ]
     @test isequal(expandeq(eqs, D(ρ); protect = Set(ℋ)), -4ℋ*ρ)
 end
+
+@testset "High lmax" begin
+    M = ΛCDM(lmax = 32)
+    prob = CosmologyProblem(M, pars)
+    @test issuccess(solve(prob, [1e-1, 1e0, 1e1, 1e2, 1e3]))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -177,7 +177,7 @@ end
 
     # Check that Fₗ(0) ∝ kˡ
     Fls = sol([M.γ.F0; collect(M.γ.F)], τini, ks)
-    @test all(Fls[:,1] ./ Fls[:,2] .≈ map(l -> (ks[1]/ks[2])^l, 0:size(Fls)[1]-1))
+    @test all(isapprox.(Fls[:,1] ./ Fls[:,2], map(l -> (ks[1]/ks[2])^l, 0:size(Fls)[1]-1))[1:4])
 
     # Check initial ratio of metric potentials
     @test all(isapprox.(sol(M.g.Φ / M.g.Ψ, τini, ks), sol((1+2/5*M.fν), τini); atol = 1e-4))


### PR DESCRIPTION
E.g. `lmax = 32` stopped working, probably because of some change to how ModelingToolkit expands the initial conditions, which are presumably done recursively for the $\ell$-hierarchy:

<img width="998" height="745" alt="bilde" src="https://github.com/user-attachments/assets/4314b22a-7f2b-476a-81f6-534cf797ddd7" />

The multipoles quickly go to zero, so I can simply truncate them to zero for all but the few first $\ell$.