### PR TITLE
Improve line-of-sight integration

### DIFF
--- a/docs/src/comparison.md
+++ b/docs/src/comparison.md
@@ -417,19 +417,19 @@ Dl2 = Dl_symboltz([:TT, :TE, :EE, :ψψ, :ψT, :ψE], jl, pars)
 plot_compare(l, l, Dl1[:, 1], Dl2[:, 1], "l", "Dₗ(TT)"; tol = 2e-12)
 ```
 ```@example class
-plot_compare(l, l, Dl1[:, 2], Dl2[:, 2], "l", "Dₗ(TE)"; tol = 3e-14)
+plot_compare(l, l, Dl1[:, 2], Dl2[:, 2], "l", "Dₗ(TE)"; tol = 4e-14)
 ```
 ```@example class
 plot_compare(l, l, Dl1[:, 3], Dl2[:, 3], "l", "Dₗ(EE)"; tol = 8e-15)
 ```
 ```@example class
-plot_compare(l, l, Dl1[:, 4], Dl2[:, 4], "l", "Dₗ(ψψ)"; tol = 5e-13)
+plot_compare(l, l, Dl1[:, 4], Dl2[:, 4], "l", "Dₗ(ψψ)"; tol = 4e-13)
 ```
 ```@example class
 plot_compare(l, l, Dl1[:, 5], Dl2[:, 5], "l", "Dₗ(ψT)"; tol = 5e-13)
 ```
 ```@example class
-plot_compare(l, l, Dl1[:, 6], Dl2[:, 6], "l", "Dₗ(ψE)"; tol = 3e-15)
+plot_compare(l, l, Dl1[:, 6], Dl2[:, 6], "l", "Dₗ(ψE)"; tol = 5e-15)
 ```
 ```@example class
 diffpars = [M.c.Ω₀, M.b.Ω₀, M.g.h]

--- a/docs/src/comparison.md
+++ b/docs/src/comparison.md
@@ -426,7 +426,7 @@ plot_compare(l, l, Dl1[:, 3], Dl2[:, 3], "l", "Dₗ(EE)"; tol = 8e-15)
 plot_compare(l, l, Dl1[:, 4], Dl2[:, 4], "l", "Dₗ(ψψ)"; tol = 5e-13)
 ```
 ```@example class
-plot_compare(l, l, Dl1[:, 5], Dl2[:, 5], "l", "Dₗ(ψT)"; tol = 3e-13)
+plot_compare(l, l, Dl1[:, 5], Dl2[:, 5], "l", "Dₗ(ψT)"; tol = 5e-13)
 ```
 ```@example class
 plot_compare(l, l, Dl1[:, 6], Dl2[:, 6], "l", "Dₗ(ψE)"; tol = 3e-15)

--- a/src/observables/angular.jl
+++ b/src/observables/angular.jl
@@ -18,6 +18,7 @@ function SphericalBesselCache(ls::AbstractVector; xmax = 10*ls[end], dx = 2π/48
     xmin = 0.0
     xs = range(xmin, xmax, length = trunc(Int, (xmax - xmin) / dx)) # fixed length (so endpoints are exact) that gives step as close to dx as possible
     invdx = 1.0 / step(xs) # using the resulting step, which need not be exactly dx
+    xs = collect([xs; xs[end]]) # pad with 1 extra duplicate point to avoid bounds check during interpolation
 
     is = zeros(Int, maximum(ls))
     ys = zeros(Float64, (length(xs), length(ls)))
@@ -26,7 +27,6 @@ function SphericalBesselCache(ls::AbstractVector; xmax = 10*ls[end], dx = 2π/48
         ys[:, i] .= jl.(l, xs)
     end
 
-    xs = collect(xs)
     return SphericalBesselCache{typeof(xs)}(ls, is, ys, invdx, xs)
 end
 
@@ -34,7 +34,7 @@ end
 @fastmath function (jl::SphericalBesselCache)(l, x)
     il = jl.i[l]
     ix₋ = 1+trunc(Int, x*jl.invdx) # faster than searchsortedfirst(jl.x, x)
-    ix₊ = min(ix₋ + 1, length(jl.x))
+    ix₊ = ix₋ + 1
     x₋ = jl.x[ix₋]
     y₋ = jl.y[ix₋, il]
     y₊ = jl.y[ix₊, il]

--- a/src/observables/angular.jl
+++ b/src/observables/angular.jl
@@ -31,14 +31,13 @@ function SphericalBesselCache(ls::AbstractVector; xmax = 10*ls[end], dx = 2π/48
 end
 
 # TODO: define chain rule like in https://github.com/JuliaDiff/ForwardDiff.jl/blob/master/src/dual.jl?
-@fastmath function (jl::SphericalBesselCache)(l, x)
+Base.@propagate_inbounds @fastmath function (jl::SphericalBesselCache)(l, x)
     il = jl.i[l]
-    ix₋ = 1+trunc(Int, x*jl.invdx) # faster than searchsortedfirst(jl.x, x)
-    ix₊ = ix₋ + 1
-    x₋ = jl.x[ix₋]
-    y₋ = jl.y[ix₋, il]
-    y₊ = jl.y[ix₊, il]
-    w = (x - x₋) * jl.invdx
+    w = x * jl.invdx # 0-based float index (assume x0 = 0)
+    i = trunc(Int, w) # 0-based integer index of left interval point; faster than searchsortedfirst(jl.x, x)
+    w = w - i # remainder ∈ [0, 1]
+    y₋ = jl.y[i+1, il] # +1 for 1-based indexing
+    y₊ = jl.y[i+2, il]
     return muladd(w, y₊ - y₋, y₋) # i.e. y₋ + (y₊ - y₋) * (x - x₋) * jl.invdx
 end
 

--- a/src/observables/angular.jl
+++ b/src/observables/angular.jl
@@ -116,7 +116,7 @@ function los_integrate(Ss::AbstractArray{T, 3}, ls::AbstractVector, τs::Abstrac
         @inbounds begin
         l = ls[il]
         verbose && print("\rLOS integrating with l = $l")
-        for ik in eachindex(ks)
+        for ik in reverse(eachindex(ks))
             k = ks[ik]
             if l ≥ l_limber
                 χ = (l+1/2) / k
@@ -160,6 +160,7 @@ function los_integrate(Ss::AbstractArray{T, 3}, ls::AbstractVector, τs::Abstrac
             for iS in 1:NS
                 Is[iS, ik, il] = _Is[iS]
             end
+            maximum(abs.(_Is)) < 1e-20 && break # multipole cut approximation
         end
         end
     end

--- a/src/observables/angular.jl
+++ b/src/observables/angular.jl
@@ -137,18 +137,24 @@ function los_integrate(Ss::AbstractArray{T, 3}, ls::AbstractVector, τs::Abstrac
                     end
                 end
             else
-                prevs .= .0 # jl = 0 when χ = 0
-                _Is .= 0.0
-                for iτ in length(τs)-1:-1:1
+                χ = χs[1] # set up first point
+                _jl = jl(l, k*χ)
+                @inbounds @simd for iS in 1:NS
+                    prevs[iS]  = Ss[iS, 1, ik] * _jl
+                    _Is[iS] = 0.0
+                end
+                for iτ in 2:length(τs)
                     χ = χs[iτ]
-                    _jl = jl(l, k*χ)
-                    halfdτ = halfdτs[iτ]
+                    kχ = k * χ
+                    _jl = jl(l, kχ)
+                    halfdτ = halfdτs[iτ-1]
                     @inbounds @simd for iS in 1:NS
                         prev = prevs[iS]
                         curr = Ss[iS, iτ, ik] * _jl
                         _Is[iS] += halfdτ * (curr + prev)
                         prevs[iS] = curr
                     end
+                    kχ < l && isapprox(_jl, 0.0; atol = 1e-20) && break # time cut approximation
                 end
             end
             for iS in 1:NS

--- a/src/observables/angular.jl
+++ b/src/observables/angular.jl
@@ -208,7 +208,7 @@ function spectrum_cmb(ΘlAs::AbstractMatrix, ΘlBs::AbstractMatrix, P0s::Abstrac
 end
 
 """
-    spectrum_cmb(modes::AbstractVector{<:Symbol}, prob::CosmologyProblem, jl::SphericalBesselCache; normalization = :Cl, unit = nothing, kτ0s = 0.1*jl.l[begin]:2π/2:10*jl.l[end], xs = 0.0:0.0008:1.0, l_limber = 50, integrator = TrapezoidalRule(), bgopts = (alg = bgalg(prob), reltol = 1e-7, abstol = 1e-7), ptopts = (alg = ptalg(prob),, reltol = 1e-5, abstol = 1e-5), sourceopts = (rtol = 1e-3, atol = 0.9), coarse_length = 9, thread = true, verbose = false, kwargs...)
+    spectrum_cmb(modes::AbstractVector{<:Symbol}, prob::CosmologyProblem, jl::SphericalBesselCache; normalization = :Cl, unit = nothing, kτ0s = 0.1*jl.l[begin]:2π/2:10*jl.l[end], xs = 0.0:0.0008:1.0, l_limber = 50, integrator = TrapezoidalRule(), bgopts = (alg = bgalg(prob), reltol = 1e-7, abstol = 1e-7), ptopts = (alg = ptalg(prob),, reltol = 1e-5, abstol = 1e-5), sourceopts = (rtol = 1e-3, atol = 0.9), downsampleopts = (tol = 1e-3,), coarse_length = 9, thread = true, verbose = false, kwargs...)
 
 Compute angular CMB power spectra ``Cₗᴬᴮ`` at angular wavenumbers `ls` from the cosmological problem `prob`.
 The requested `modes` are specified as a vector of symbols in the form `:AB`, where `A` and `B` are `T` (temperature), `E` (E-mode polarization) or `ψ` (lensing).
@@ -234,7 +234,7 @@ modes = [:TT, :TE, :ψψ, :ψT]
 Dls = spectrum_cmb(modes, prob, jl; normalization = :Dl, unit = u"μK")
 ```
 """
-function spectrum_cmb(modes::AbstractVector{<:Symbol}, prob::CosmologyProblem, jl::SphericalBesselCache; normalization = :Cl, unit = nothing, kτ0s = 0.1*jl.l[begin]:2π/2:10*jl.l[end], xs = 0.0:0.0008:1.0, l_limber = 50, integrator = TrapezoidalRule(), bgopts = (alg = bgalg(prob), reltol = 1e-7, abstol = 1e-7), ptopts = (alg = ptalg(prob), reltol = 1e-5, abstol = 1e-5), sourceopts = (rtol = 1e-3, atol = 0.9), coarse_length = 9, thread = true, verbose = false, kwargs...)
+function spectrum_cmb(modes::AbstractVector{<:Symbol}, prob::CosmologyProblem, jl::SphericalBesselCache; normalization = :Cl, unit = nothing, kτ0s = 0.1*jl.l[begin]:2π/2:10*jl.l[end], xs = 0.0:0.0008:1.0, l_limber = 50, integrator = TrapezoidalRule(), bgopts = (alg = bgalg(prob), reltol = 1e-7, abstol = 1e-7), ptopts = (alg = ptalg(prob), reltol = 1e-5, abstol = 1e-5), sourceopts = (rtol = 1e-3, atol = 0.9), downsampleopts = (tol = 1e-3,), coarse_length = 9, thread = true, verbose = false, kwargs...)
     ls = jl.l
     sol = solve(prob; bgopts, verbose)
     τ0 = getsym(sol, prob.M.τ0)(sol)
@@ -255,6 +255,9 @@ function spectrum_cmb(modes::AbstractVector{<:Symbol}, prob::CosmologyProblem, j
     Ss = [prob.M.ST, prob.M.SE_kχ², prob.M.Sψ]
     ks_coarse = range(ks_fine[begin], ks_fine[end]; length = coarse_length)
     ks_coarse, Ss_coarse = source_grid_adaptive(prob, Ss, τs, ks_coarse, sol.bg; ptopts, verbose, thread, sourceopts...) # TODO: pass kτ0 and x
+
+    # Downsample source function in τ
+    Ss_coarse, τs = source_grid_downsample(Ss_coarse, τs; downsampleopts...)
 
     # Interpolate source function to finer k-grid
     Ss_fine = source_grid(Ss_coarse, ks_coarse, ks_fine; thread)

--- a/src/observables/angular.jl
+++ b/src/observables/angular.jl
@@ -193,7 +193,7 @@ function spectrum_cmb(ΘlAs::AbstractMatrix, ΘlBs::AbstractMatrix, P0s::Abstrac
 end
 
 """
-    spectrum_cmb(modes::AbstractVector{<:Symbol}, prob::CosmologyProblem, jl::SphericalBesselCache; normalization = :Cl, unit = nothing, kτ0s = 0.1*jl.l[begin]:2π/2:10*jl.l[end], xs = 0.0:0.0008:1.0, l_limber = 10, integrator = TrapezoidalRule(), bgopts = (alg = bgalg(prob), reltol = 1e-7, abstol = 1e-7), ptopts = (alg = ptalg(prob),, reltol = 1e-5, abstol = 1e-5), sourceopts = (rtol = 1e-3, atol = 0.9), downsampleopts = (tol = 1e-3,), coarse_length = 9, thread = true, verbose = false, kwargs...)
+    spectrum_cmb(modes::AbstractVector{<:Symbol}, prob::CosmologyProblem, jl::SphericalBesselCache; normalization = :Cl, unit = nothing, kτ0s = 0.1*jl.l[begin]:2π/2:10*jl.l[end], xs = 0.0:0.0008:1.0, l_limber = 10, integrator = TrapezoidalRule(), bgopts = (alg = bgalg(prob), reltol = 1e-7, abstol = 1e-7), ptopts = (alg = ptalg(prob),, reltol = 1e-5, abstol = 1e-5), sourceopts = (rtol = 1e-3, atol = 0.9), downsampleopts = (Ttol = 4e-3, Etol = 3e-4, ψtol = 1e-3), coarse_length = 9, thread = true, verbose = false, kwargs...)
 
 Compute angular CMB power spectra ``Cₗᴬᴮ`` at angular wavenumbers `ls` from the cosmological problem `prob`.
 The requested `modes` are specified as a vector of symbols in the form `:AB`, where `A` and `B` are `T` (temperature), `E` (E-mode polarization) or `ψ` (lensing).
@@ -219,7 +219,7 @@ modes = [:TT, :TE, :ψψ, :ψT]
 Dls = spectrum_cmb(modes, prob, jl; normalization = :Dl, unit = u"μK")
 ```
 """
-function spectrum_cmb(modes::AbstractVector{<:Symbol}, prob::CosmologyProblem, jl::SphericalBesselCache; normalization = :Cl, unit = nothing, kτ0s = 0.1*jl.l[begin]:2π/2:10*jl.l[end], xs = 0.0:0.0008:1.0, l_limber = 10, integrator = TrapezoidalRule(), bgopts = (alg = bgalg(prob), reltol = 1e-7, abstol = 1e-7), ptopts = (alg = ptalg(prob), reltol = 1e-5, abstol = 1e-5), sourceopts = (rtol = 1e-3, atol = 0.9), downsampleopts = (tol = 1e-3,), coarse_length = 9, thread = true, verbose = false, kwargs...)
+function spectrum_cmb(modes::AbstractVector{<:Symbol}, prob::CosmologyProblem, jl::SphericalBesselCache; normalization = :Cl, unit = nothing, kτ0s = 0.1*jl.l[begin]:2π/2:10*jl.l[end], xs = 0.0:0.0008:1.0, l_limber = 10, integrator = TrapezoidalRule(), bgopts = (alg = bgalg(prob), reltol = 1e-7, abstol = 1e-7), ptopts = (alg = ptalg(prob), reltol = 1e-5, abstol = 1e-5), sourceopts = (rtol = 1e-3, atol = 0.9), downsampleopts = (Ttol = 4e-3, Etol = 3e-4, ψtol = 1e-3), coarse_length = 9, thread = true, verbose = false, kwargs...)
     ls = jl.l
     sol = solve(prob; bgopts, verbose)
     τ0 = getsym(sol, prob.M.τ0)(sol)
@@ -239,26 +239,28 @@ function spectrum_cmb(modes::AbstractVector{<:Symbol}, prob::CosmologyProblem, j
     iψ = 'ψ' in join(modes) ? max(iE, iT) + 1 : 0
     Ss = [prob.M.ST, prob.M.SE_kχ², prob.M.Sψ]
     ks_coarse = range(ks_fine[begin], ks_fine[end]; length = coarse_length)
-    ks_coarse, Ss_coarse = source_grid_adaptive(prob, Ss, τs, ks_coarse, sol.bg; ptopts, verbose, thread, sourceopts...) # TODO: pass kτ0 and x
+    ks_coarse, Ss = source_grid_adaptive(prob, Ss, τs, ks_coarse, sol.bg; ptopts, verbose, thread, sourceopts...) # TODO: pass kτ0 and x
 
-    # Downsample source function in τ
-    Ss_coarse, τs = source_grid_downsample(Ss_coarse, τs; downsampleopts...)
-
-    # Interpolate source function to finer k-grid
-    Ss_fine = source_grid(Ss_coarse, ks_coarse, ks_fine; thread)
-    χs = τs[end] .- τs
-    Ss_fine[2, :, :] ./= (ks_fine' .* χs) .^ 2
-    Ss_fine[:, end, :] .= 0.0 # can be Inf, but is always weighted by zero-valued spherical Bessel function in LOS integration
-
-    Θls = zeros(eltype(Ss_fine), max(iT, iE, iψ), length(ks_fine), length(ls))
+    Θls = zeros(eltype(Ss), max(iT, iE, iψ), length(ks_fine), length(ls))
     if iT > 0
-        Θls[iT, :, :] .= los_integrate(Ss_fine[1, :, :], ls, τs, ks_fine, jl; integrator, verbose, thread, kwargs...)
+        STs, τTs = source_grid_downsample(Ss[1, :, :], τs; tol = downsampleopts.Ttol) # downsample in τ
+        verbose && println("Downsampled T source function from ", length(τs), " to ", length(τTs), " time points")
+        STs = source_grid(STs, ks_coarse, ks_fine; thread) # upsample in k
+        Θls[iT, :, :] .= los_integrate(STs, ls, τTs, ks_fine, jl; integrator, verbose, thread, kwargs...)
     end
     if iE > 0
-        Θls[iE, :, :] .= transpose(@. √((ls+2)*(ls+1)*(ls+0)*(ls-1))) .* los_integrate(Ss_fine[2, :, :], ls, τs, ks_fine, jl; integrator, verbose, thread, kwargs...)
+        SEs, τEs = source_grid_downsample(Ss[2, :, :], τs; tol = downsampleopts.Etol) # downsample in τ
+        verbose && println("Downsampled E source function from ", length(τs), " to ", length(τEs), " time points")
+        @. SEs ./= (ks_coarse' * (τ0-τEs))^2
+        SEs[end, :] .= 0.0 # can be Inf, but is always weighted by zero-valued spherical Bessel function in LOS integration
+        SEs = source_grid(SEs, ks_coarse, ks_fine; thread) # upsample in k
+        Θls[iE, :, :] .= transpose(@. √((ls+2)*(ls+1)*(ls+0)*(ls-1))) .* los_integrate(SEs, ls, τEs, ks_fine, jl; integrator, verbose, thread, kwargs...)
     end
     if iψ > 0
-        Θls[iψ, :, :] .= los_integrate(Ss_fine[3, :, :], ls, τs, ks_fine, jl; l_limber, integrator, verbose, thread, kwargs...)
+        Sψs, τψs = source_grid_downsample(Ss[3, :, :], τs; tol = downsampleopts.ψtol) # downsample in τ
+        verbose && println("Downsampled ψ source function from ", length(τs), " to ", length(τψs), " time points")
+        Sψs = source_grid(Sψs, ks_coarse, ks_fine; thread) # upsample in k
+        Θls[iψ, :, :] .= los_integrate(Sψs, ls, τψs, ks_fine, jl; l_limber, integrator, verbose, thread, kwargs...)
     end
 
     P0s = spectrum_primordial(ks_fine, sol) # more accurate
@@ -278,7 +280,7 @@ function spectrum_cmb(modes::AbstractVector{<:Symbol}, prob::CosmologyProblem, j
         error("Unknown CMB power spectrum mode $mode")
     end
 
-    spectra = zeros(eltype(Ss_fine[1,1,1] * P0s[1] * factor^2), length(ls), length(modes)) # Cls or Dls
+    spectra = zeros(eltype(Ss[1,1,1] * P0s[1] * factor^2), length(ls), length(modes)) # Cls or Dls
     for (i, mode) in enumerate(modes)
         mode = String(mode)
         iA = geti(Symbol(mode[firstindex(mode)]))

--- a/src/observables/angular.jl
+++ b/src/observables/angular.jl
@@ -118,10 +118,10 @@ is used for `l ≥ l_limber`.
                 χ = (l+1/2) / k
                 if χ ≤ χs[1] # otherwise χ > χini > χrec and source function is definitely zero
                     # interpolate between two closest points in saved array
-                    iχ₋ = searchsortedfirst(χs, χ; rev = true)
-                    iχ₊ = iχ₋ - 1
-                    χ₋, χ₊ = χs[iχ₋], χs[iχ₊] # now χ₋ < χ < χ₊
-                    S₋, S₊ = Ss[iχ₋, ik], Ss[iχ₊, ik]
+                    i₋ = searchsortedfirst(τs, τ0 - χ)
+                    i₊ = i₋ - 1 # χ is sorted in descending order
+                    χ₋, χ₊ = χs[i₋], χs[i₊] # now χ₋ < χ < χ₊
+                    S₋, S₊ = Ss[i₋, ik], Ss[i₊, ik]
                     S = S₋ + (S₊-S₋) * (χ-χ₋) / (χ₊-χ₋)
                     I = √(π/(2l+1)) * S / k
                 end

--- a/src/observables/angular.jl
+++ b/src/observables/angular.jl
@@ -215,7 +215,7 @@ function spectrum_cmb(ΘlAs::AbstractMatrix, ΘlBs::AbstractMatrix, P0s::Abstrac
 end
 
 """
-    spectrum_cmb(modes::AbstractVector{<:Symbol}, prob::CosmologyProblem, jl::SphericalBesselCache; normalization = :Cl, unit = nothing, kτ0s = 0.1*jl.l[begin]:2π/2:10*jl.l[end], xs = 0.0:0.0008:1.0, l_limber = 50, integrator = TrapezoidalRule(), bgopts = (alg = bgalg(prob), reltol = 1e-7, abstol = 1e-7), ptopts = (alg = ptalg(prob),, reltol = 1e-5, abstol = 1e-5), sourceopts = (rtol = 1e-3, atol = 0.9), downsampleopts = (tol = 1e-3,), coarse_length = 9, thread = true, verbose = false, kwargs...)
+    spectrum_cmb(modes::AbstractVector{<:Symbol}, prob::CosmologyProblem, jl::SphericalBesselCache; normalization = :Cl, unit = nothing, kτ0s = 0.1*jl.l[begin]:2π/2:10*jl.l[end], xs = 0.0:0.0008:1.0, l_limber = 10, integrator = TrapezoidalRule(), bgopts = (alg = bgalg(prob), reltol = 1e-7, abstol = 1e-7), ptopts = (alg = ptalg(prob),, reltol = 1e-5, abstol = 1e-5), sourceopts = (rtol = 1e-3, atol = 0.9), downsampleopts = (tol = 1e-3,), coarse_length = 9, thread = true, verbose = false, kwargs...)
 
 Compute angular CMB power spectra ``Cₗᴬᴮ`` at angular wavenumbers `ls` from the cosmological problem `prob`.
 The requested `modes` are specified as a vector of symbols in the form `:AB`, where `A` and `B` are `T` (temperature), `E` (E-mode polarization) or `ψ` (lensing).
@@ -241,7 +241,7 @@ modes = [:TT, :TE, :ψψ, :ψT]
 Dls = spectrum_cmb(modes, prob, jl; normalization = :Dl, unit = u"μK")
 ```
 """
-function spectrum_cmb(modes::AbstractVector{<:Symbol}, prob::CosmologyProblem, jl::SphericalBesselCache; normalization = :Cl, unit = nothing, kτ0s = 0.1*jl.l[begin]:2π/2:10*jl.l[end], xs = 0.0:0.0008:1.0, l_limber = 50, integrator = TrapezoidalRule(), bgopts = (alg = bgalg(prob), reltol = 1e-7, abstol = 1e-7), ptopts = (alg = ptalg(prob), reltol = 1e-5, abstol = 1e-5), sourceopts = (rtol = 1e-3, atol = 0.9), downsampleopts = (tol = 1e-3,), coarse_length = 9, thread = true, verbose = false, kwargs...)
+function spectrum_cmb(modes::AbstractVector{<:Symbol}, prob::CosmologyProblem, jl::SphericalBesselCache; normalization = :Cl, unit = nothing, kτ0s = 0.1*jl.l[begin]:2π/2:10*jl.l[end], xs = 0.0:0.0008:1.0, l_limber = 10, integrator = TrapezoidalRule(), bgopts = (alg = bgalg(prob), reltol = 1e-7, abstol = 1e-7), ptopts = (alg = ptalg(prob), reltol = 1e-5, abstol = 1e-5), sourceopts = (rtol = 1e-3, atol = 0.9), downsampleopts = (tol = 1e-3,), coarse_length = 9, thread = true, verbose = false, kwargs...)
     ls = jl.l
     sol = solve(prob; bgopts, verbose)
     τ0 = getsym(sol, prob.M.τ0)(sol)

--- a/src/observables/angular.jl
+++ b/src/observables/angular.jl
@@ -78,90 +78,68 @@ ChainRulesCore.frule((_, _, Δx), ::typeof(jl), l, x) = jl(l, x), jl′(l, x) * 
 # TODO: use u = k*χ as integration variable, so oscillations of Bessel functions are the same for every k?
 # TODO: define and document symbolic dispatch!
 """
-    los_integrate(Ss::AbstractArray{T, 3}, ls::AbstractVector, τs::AbstractVector, ks::AbstractVector, jl::SphericalBesselCache; l_limber = typemax(Int), integrator = TrapezoidalRule(), thread = true, verbose = false) where {T <: Real}
+    los_integrate(Ss::AbstractMatrix{T}, ls::AbstractVector, τs::AbstractVector, ks::AbstractVector, jl::SphericalBesselCache; l_limber = typemax(Int), integrator = TrapezoidalRule(), thread = true, verbose = false) where {T <: Real}
 
 For the given `ls` and `ks`, compute the line-of-sight-integrals
 ```math
 Iₗ(k) = ∫dτ S(k,τ) jₗ(k(τ₀-τ))
 ```
 over the source function values `Ss` against the spherical Bessel functions ``jₗ(x)`` cached in `jl`.
-The element `Ss[i,j,k]` holds the source function value ``Sᵢ(kⱼ, τₖ)``.
+The element `Ss[i,j]` holds the source function value ``S(τᵢ, kⱼ)``.
 The limber approximation
 ```math
-Iₗ ≈ √(π/(2l+1)) S(k,τ₀-(l+1/2)/k)
+Iₗ ≈ √(π/(2l+1)) S(τ₀-(l+1/2)/k, k)
 ```
 is used for `l ≥ l_limber`.
 """
-function los_integrate(Ss::AbstractArray{T, 3}, ls::AbstractVector, τs::AbstractVector, ks::AbstractVector, jl::SphericalBesselCache; l_limber = typemax(Int), integrator = TrapezoidalRule(), thread = true, verbose = false) where {T <: Real}
+@fastmath function los_integrate(Ss::AbstractMatrix{T}, ls::AbstractVector, τs::AbstractVector, ks::AbstractVector, jl::SphericalBesselCache; l_limber = typemax(Int), integrator = TrapezoidalRule(), thread = true, verbose = false) where {T <: Real}
     # Julia is column-major; make sure innermost loop indices appear first in slice expressions (https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-column-major)
-    @assert size(Ss, 2) == length(τs) "size(Ss, 2) = $(size(Ss, 2)) and length(τs) = $(length(τs)) differ"
-    @assert size(Ss, 3) == length(ks) "size(Ss, 3) = $(size(Ss, 3)) and length(ks) = $(length(ks)) differ"
+    @assert size(Ss, 1) == length(τs) "size(Ss, 1) = $(size(Ss, 1)) and length(τs) = $(length(τs)) differ"
+    @assert size(Ss, 2) == length(ks) "size(Ss, 2) = $(size(Ss, 2)) and length(ks) = $(length(ks)) differ"
     @assert jl.x[begin] ≤ 0 "jl.x[begin] < 0"
     @assert jl.x[end] ≥ ks[end]*τs[end] "jl.x[end] < kmax*τmax"
     τs = collect(τs) # force array to avoid floating point errors with ranges in following χs due to (e.g. tiny negative χ)
-    χs = τs[end] .- τs
+    τ0 = τs[end]
+    χs = τ0 .- τs
     halfdτs = 0.5 .* (τs[begin+1:end] .- τs[begin:end-1]) # precompute before loops
-    NS = size(Ss, 1)
-    Is = zeros(eltype(Ss), NS, length(ks), length(ls))
+    Is = zeros(T, length(ks), length(ls))
 
     verbose && l_limber < typemax(Int) && println("Using Limber approximation for l ≥ $l_limber")
 
     # TODO: skip and set jl to zero if l ≳ kτ0 or another cutoff?
-    @tasks for il in eachindex(ls) # parallellize independent loop iterations
+    @inbounds @tasks for il in eachindex(ls) # parallellize independent loop iterations
         @set scheduler = thread ? :dynamic : :serial
-        @local begin # define task-local values (declared once for all loop iterations)
-            prevs = similar(Ss, NS)
-            _Is = similar(Ss, NS)
-        end
-        @inbounds begin
         l = ls[il]
         verbose && print("\rLOS integrating with l = $l")
         for ik in reverse(eachindex(ks))
             k = ks[ik]
+            I = 0.0
             if l ≥ l_limber
                 χ = (l+1/2) / k
-                if χ > χs[1]
-                    # χ > χini > χrec, so source function is definitely zero
-                    for iS in 1:NS
-                        _Is[iS] = 0.0
-                    end
-                else
+                if χ ≤ χs[1] # otherwise χ > χini > χrec and source function is definitely zero
                     # interpolate between two closest points in saved array
                     iχ₋ = searchsortedfirst(χs, χ; rev = true)
                     iχ₊ = iχ₋ - 1
                     χ₋, χ₊ = χs[iχ₋], χs[iχ₊] # now χ₋ < χ < χ₊
-                    @inbounds @simd for iS in 1:NS
-                        S₋, S₊ = Ss[iS, iχ₋, ik], Ss[iS, iχ₊, ik]
-                        S = S₋ + (S₊-S₋) * (χ-χ₋) / (χ₊-χ₋)
-                        _Is[iS] = √(π/(2l+1)) * S / k
-                    end
+                    S₋, S₊ = Ss[iχ₋, ik], Ss[iχ₊, ik]
+                    S = S₋ + (S₊-S₋) * (χ-χ₋) / (χ₊-χ₋)
+                    I = √(π/(2l+1)) * S / k
                 end
             else
-                χ = χs[1] # set up first point
-                _jl = jl(l, k*χ)
-                @inbounds @simd for iS in 1:NS
-                    prevs[iS]  = Ss[iS, 1, ik] * _jl
-                    _Is[iS] = 0.0
-                end
+                prev = Ss[1, ik] * jl(l, k*χs[1]) # set up first point
                 for iτ in 2:length(τs)
-                    χ = χs[iτ]
-                    kχ = k * χ
-                    _jl = jl(l, kχ)
+                    kχ = k * χs[iτ]
                     halfdτ = halfdτs[iτ-1]
-                    @inbounds @simd for iS in 1:NS
-                        prev = prevs[iS]
-                        curr = Ss[iS, iτ, ik] * _jl
-                        _Is[iS] += halfdτ * (curr + prev)
-                        prevs[iS] = curr
-                    end
-                    kχ < l && isapprox(_jl, 0.0; atol = 1e-20) && break # time cut approximation
+                    _jl = jl(l, kχ)
+                    curr = Ss[iτ, ik] * _jl
+                    dI = halfdτ * (curr + prev)
+                    I += dI
+                    kχ < l && abs(_jl) < 1e-20 && break # time cut approximation
+                    prev = curr
                 end
             end
-            for iS in 1:NS
-                Is[iS, ik, il] = _Is[iS]
-            end
-            maximum(abs.(_Is)) < 1e-20 && break # multipole cut approximation
-        end
+            Is[ik, il] = I
+            k*τ0 < l && abs(I) < 1e-20 && break # multipole cut approximation
         end
     end
     verbose && println()
@@ -273,15 +251,14 @@ function spectrum_cmb(modes::AbstractVector{<:Symbol}, prob::CosmologyProblem, j
     Ss_fine[:, end, :] .= 0.0 # can be Inf, but is always weighted by zero-valued spherical Bessel function in LOS integration
 
     Θls = zeros(eltype(Ss_fine), max(iT, iE, iψ), length(ks_fine), length(ls))
-    iTE = max(iT, iE)
-    if iTE > 0
-        Θls[1:iTE, :, :] .= los_integrate(@view(Ss_fine[1:iTE, :, :]), ls, τs, ks_fine, jl; integrator, verbose, thread, kwargs...)
+    if iT > 0
+        Θls[iT, :, :] .= los_integrate(Ss_fine[1, :, :], ls, τs, ks_fine, jl; integrator, verbose, thread, kwargs...)
     end
     if iE > 0
-        Θls[iE, :, :] .*= transpose(@. √((ls+2)*(ls+1)*(ls+0)*(ls-1)))
+        Θls[iE, :, :] .= transpose(@. √((ls+2)*(ls+1)*(ls+0)*(ls-1))) .* los_integrate(Ss_fine[2, :, :], ls, τs, ks_fine, jl; integrator, verbose, thread, kwargs...)
     end
     if iψ > 0
-        Θls[iψ:iψ, :, :] .= los_integrate(@view(Ss_fine[3:3, :, :]), ls, τs, ks_fine, jl; l_limber, integrator, verbose, thread, kwargs...)
+        Θls[iψ, :, :] .= los_integrate(Ss_fine[3, :, :], ls, τs, ks_fine, jl; l_limber, integrator, verbose, thread, kwargs...)
     end
 
     P0s = spectrum_primordial(ks_fine, sol) # more accurate

--- a/src/observables/fourier.jl
+++ b/src/observables/fourier.jl
@@ -214,16 +214,16 @@ function source_grid(sol::CosmologySolution, Ss::AbstractVector, τs; thread = t
 end
 
 """
-    source_grid(Ss_coarse::AbstractArray, ks_coarse, ks_fine; ktransform = identity, thread = true)
+    source_grid(Ss_coarse::AbstractMatrix{<:Real}, ks_coarse, ks_fine; ktransform = identity, thread = true)
 
 Interpolate values `Ss_coarse` of source functions ``S(τ,k)`` from a coarse wavenumber grid `ks_coarse` to a fine grid `ks_fine`.
 The interpolation is linear in `ktransform(k)` (e.g. `identity` for interpolation in ``k`` or `log` for interpolation in ``\\ln k``.
 Conformal times are unchanged.
 """
-function source_grid(Ss_coarse::AbstractArray, ks_coarse, ks_fine; ktransform = identity, thread = true)
+function source_grid(Ss_coarse::AbstractMatrix{<:Real}, ks_coarse, ks_fine; ktransform = identity, thread = true)
     size_coarse = size(Ss_coarse)
-    size_fine = (size_coarse[1], size_coarse[2], length(ks_fine))
-    Ns, Nτ, Nk = size(Ss_coarse)
+    size_fine = (size_coarse[1], length(ks_fine))
+    Nτ, Nk = size(Ss_coarse)
 
     Nk == length(ks_coarse) || error("Length of coarse k-grid does not match source array")
 
@@ -232,10 +232,8 @@ function source_grid(Ss_coarse::AbstractArray, ks_coarse, ks_fine; ktransform = 
     xs_fine = ktransform.(ks_fine)
     @tasks for iτ in 1:Nτ
         @set scheduler = thread ? :dynamic : :static
-        for iS in 1:Ns
-            interp = LinearInterpolation(@view(Ss_coarse[iS, iτ, :]), xs_coarse)
-            Ss_fine[iS, iτ, :] .= interp.(xs_fine)
-        end
+        interp = LinearInterpolation(@view(Ss_coarse[iτ, :]), xs_coarse)
+        Ss_fine[iτ, :] .= interp.(xs_fine)
     end
     return Ss_fine
 end
@@ -390,8 +388,8 @@ Base.@propagate_inbounds function source_grid_downsample_refine(is, Ss, τs, i1,
     i = trunc(Int, (i1+i2)/2)
     if i ≠ i1
         w = (τs[i] - τs[i1]) / (τs[i2] - τs[i1]) # ∈ [0, 1]; interpolation point may not be exactly halfway
-        @. Sint = Ss[:, i1, :] + w * (Ss[:, i2, :] - Ss[:, i1, :])
-        S = @view Ss[:, i, :]
+        @. Sint = Ss[i1, :] + w * (Ss[i2, :] - Ss[i1, :])
+        S = @view Ss[i, :]
         if !isapprox(S, Sint; kwargs...)
             source_grid_downsample_refine(is, Ss, τs, i1, i, Sint; kwargs...) # refine left half-interval
             source_grid_downsample_refine(is, Ss, τs, i, i2, Sint; kwargs...) # refine right half-interval
@@ -401,12 +399,12 @@ Base.@propagate_inbounds function source_grid_downsample_refine(is, Ss, τs, i1,
     push!(is, i1) # don't refine; reached end of refinement; add left point to list
 end
 
-@inbounds function source_grid_downsample(Ss, τs; tol = 1e-3, atol = tol, rtol = tol)
+@inbounds function source_grid_downsample(Ss::AbstractMatrix{<:Real}, τs; tol = 1e-3, atol = tol, rtol = tol)
     i1 = 1
     i2 = length(τs)
     is = sizehint!(Int[], i2)
-    Sint = similar(Ss, (size(Ss, 1), size(Ss, 3))) # workspace for interpolated values
+    Sint = similar(Ss, size(Ss, 2)) # workspace for interpolated values
     source_grid_downsample_refine(is, Ss, τs, i1, i2, Sint; atol, rtol)
     push!(is, i2) # add rightmost point
-    return Ss[:, is, :], τs[is]
+    return Ss[is, :], τs[is]
 end

--- a/src/observables/fourier.jl
+++ b/src/observables/fourier.jl
@@ -384,3 +384,29 @@ function source_grid_adaptive(prob::CosmologyProblem, Ss::AbstractVector, τs, k
     bgsol = solvebg(prob.bg; bgopts...)
     return source_grid_adaptive(prob, Ss, τs, ks, bgsol; kwargs...)
 end
+
+# TODO: weight interpolation by τ
+Base.@propagate_inbounds function source_grid_downsample_refine(is, Ss, τs, i1, i2, Sint; kwargs...)
+    i = trunc(Int, (i1+i2)/2)
+    if i ≠ i1
+        w = (τs[i] - τs[i1]) / (τs[i2] - τs[i1]) # ∈ [0, 1]; interpolation point may not be exactly halfway
+        Sint .= Ss[:, i1, :] .+ w .* (Ss[:, i2, :] .- Ss[:, i1, :])
+        S = @view Ss[:, i, :]
+        if !isapprox(S, Sint; kwargs...)
+            source_grid_downsample_refine(is, Ss, τs, i1, i, Sint; kwargs...) # refine left half-interval
+            source_grid_downsample_refine(is, Ss, τs, i, i2, Sint; kwargs...) # refine right half-interval
+            return
+        end
+    end
+    push!(is, i1) # don't refine; reached end of refinement; add left point to list
+end
+
+@inbounds function source_grid_downsample(Ss, τs; tol = 1e-3, atol = tol, rtol = tol)
+    i1 = 1
+    i2 = length(τs)
+    is = sizehint!(Int[], i2)
+    Sint = similar(Ss, (size(Ss, 1), size(Ss, 3))) # workspace for interpolated values
+    source_grid_downsample_refine(is, Ss, τs, i1, i2, Sint; atol, rtol)
+    push!(is, i2) # add rightmost point
+    return Ss[:, is, :], τs[is]
+end

--- a/src/observables/fourier.jl
+++ b/src/observables/fourier.jl
@@ -390,7 +390,7 @@ Base.@propagate_inbounds function source_grid_downsample_refine(is, Ss, τs, i1,
     i = trunc(Int, (i1+i2)/2)
     if i ≠ i1
         w = (τs[i] - τs[i1]) / (τs[i2] - τs[i1]) # ∈ [0, 1]; interpolation point may not be exactly halfway
-        Sint .= Ss[:, i1, :] .+ w .* (Ss[:, i2, :] .- Ss[:, i1, :])
+        @. Sint = Ss[:, i1, :] + w * (Ss[:, i2, :] - Ss[:, i1, :])
         S = @view Ss[:, i, :]
         if !isapprox(S, Sint; kwargs...)
             source_grid_downsample_refine(is, Ss, τs, i1, i, Sint; kwargs...) # refine left half-interval

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -432,10 +432,10 @@ end
     Sgetter = SymBoltz.getsym(prob.pt, M.ST)
     Ss = @inferred source_grid(sol, [M.ST], τs) # TODO: save allocation time with out-of-place version?
     @test Ss == source_grid(prob, [M.ST], τs, ks_coarse; ptopts)
-    Ss = @inferred source_grid(Ss, ks_coarse, ks_fine) # TODO: save allocation time with out-of-place version?
+    Ss = @inferred source_grid(Ss[1, :, :], ks_coarse, ks_fine) # TODO: save allocation time with out-of-place version?
     Θ0s = @inferred los_integrate(Ss, ls, τs, ks_fine, jl) # TODO: sequential along τ? # TODO: cache kτ0 and x=τ/τ0 (only depends on l)
     P0s = @inferred spectrum_primordial(ks_fine, pars[M.g.h], prob.bg.ps[M.I.As])
-    Cls = @inferred spectrum_cmb(Θ0s[1, :, :], Θ0s[1, :, :], P0s, ls, ks_fine)
+    Cls = @inferred spectrum_cmb(Θ0s, Θ0s, P0s, ls, ks_fine)
 end
 
 @testset "Background differentiation test" begin


### PR DESCRIPTION
- [x] Speed up $j_l(x)$ interpolation logic
- [x] Downsample time points in LOS integration for best speedup
- [x] Do one new LOS integral per source, as optimal sparse time grids for temperature/polarization/lensing can be quite different
- [x] Time cut approximation when $j_l(x \rightarrow) \rightarrow 0$ (makes no difference, `<` check is expensive)
- [x] Multiople cut approximation: assign $\Delta_l(k) = 0$ directly without integration when integrals become 0 (makes no difference)
```julia
using SymBoltz
M = ΛCDM()
p = parameters_Planck18(M)
prob = CosmologyProblem(M, p)
ls = 25:25:2500
jl = SphericalBesselCache(ls)
@time Dls = spectrum_cmb([:TT, :EE, :ψψ], prob, jl; normalization = :Dl)
```
Before:  
```
  2.268953 seconds (4.00 M allocations: 921.069 MiB, 2.50% gc time)
```
After:
```
  1.216482 seconds (2.53 M allocations: 645.750 MiB)
```