### PR TITLE
Optimize line-of-sight integration

### DIFF
--- a/src/observables/angular.jl
+++ b/src/observables/angular.jl
@@ -27,33 +27,31 @@ function SphericalBesselCache(ls::AbstractVector; xmax = 20*ls[end], dx = 2π/15
         is[l] = i
     end
 
-    ys = jl.(ls', xs)
-    dys = hermite ? jl′.(ls', xs) : nothing
+    ys  = jl.(ls, xs') # contiguous in l
+    dys = hermite ? jl′.(ls, xs') : nothing
 
     return SphericalBesselCache{typeof(dys)}(ls, is, ys, dys, dx, invdx, xs)
 end
 
-# TODO: define chain rule like in https://github.com/JuliaDiff/ForwardDiff.jl/blob/master/src/dual.jl?
-Base.@propagate_inbounds @fastmath function (jl::SphericalBesselCache{Nothing})(l, x)
-    il = jl.i[l]
+# First argument is the cache index il, not the multipole l (use jl.i[l] to convert l → il)
+@inline Base.@propagate_inbounds @fastmath function (jl::SphericalBesselCache{Nothing})(il::Int, x)
     w = x * jl.invdx # 0-based float index (assume x0 = 0)
     i = trunc(Int, w) # 0-based integer index of left interval point; faster than searchsortedfirst(jl.x, x)
     w = w - i # remainder ∈ [0, 1]
-    y₋ = jl.y[i+1, il] # +1 for 1-based indexing
-    y₊ = jl.y[i+2, il]
+    y₋ = jl.y[il, i+1] # +1 for 1-based indexing
+    y₊ = jl.y[il, i+2]
     return muladd(w, y₊ - y₋, y₋) # i.e. y₋ + (y₊ - y₋) * (x - x₋) * jl.invdx
 end
 
-Base.@propagate_inbounds @fastmath function (jl::SphericalBesselCache{Matrix{Float64}})(l, x)
-    il = jl.i[l]
+@inline Base.@propagate_inbounds @fastmath function (jl::SphericalBesselCache{Matrix{Float64}})(il::Int, x)
     w = x * jl.invdx
     i = trunc(Int, w)
     w = w - i
     wm1 = w - 1.0
-    y₋ = jl.y[i+1, il]
-    y₊ = jl.y[i+2, il]
-    dy₋ = jl.dy[i+1, il]
-    dy₊ = jl.dy[i+2, il]
+    y₋  = jl.y[il, i+1]
+    y₊  = jl.y[il, i+2]
+    dy₋ = jl.dy[il, i+1]
+    dy₊ = jl.dy[il, i+2]
     return (1+2w)*wm1*wm1 * y₋ + w*w*(3-2w) * y₊ + w*wm1 * (wm1 * dy₋ + w * dy₊) * jl.dx # https://en.wikipedia.org/wiki/Cubic_Hermite_spline
 end
 

--- a/src/observables/angular.jl
+++ b/src/observables/angular.jl
@@ -115,68 +115,77 @@ Iₗ ≈ √(π/(2l+1)) S(τ₀-(l+1/2)/k, k)
 is used for `l ≥ l_limber`.
 """
 function los_integrate(Ss::AbstractMatrix{T}, ls::AbstractVector, τs::AbstractVector, ks::AbstractVector, jl::SphericalBesselCache; l_limber = typemax(Int), integrator = TrapezoidalRule(), thread = true, verbose = false) where {T}
-    # Julia is column-major; make sure innermost loop indices appear first in slice expressions (https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-column-major)
     @assert size(Ss, 1) == length(τs) "size(Ss, 1) = $(size(Ss, 1)) and length(τs) = $(length(τs)) differ"
     @assert size(Ss, 2) == length(ks) "size(Ss, 2) = $(size(Ss, 2)) and length(ks) = $(length(ks)) differ"
+    @assert collect(ls) == jl.l "ls must match the l-values stored in the Bessel cache"
     @assert jl.x[begin] ≤ 0 "jl.x[begin] < 0"
     @assert jl.x[end] ≥ ks[end]*τs[end] "jl.x[end] < kmax*τmax"
     @assert all(all(isfinite.(S)) for S in Ss) "Ss contain NaN or Inf"
     @assert τs[2] > τs[1] "τs must be sorted in ascending order"
     @assert ks[2] > ks[1] "ks must be sorted in ascending order"
+
     τs = collect(τs) # force array to avoid floating point errors with ranges in following χs due to (e.g. tiny negative χ)
     τ0 = τs[end]
     χs = τ0 .- τs
-    halfdτs = 0.5 .* (τs[begin+1:end] .- τs[begin:end-1]) # precompute before loops
-    Is = similar(Ss, length(ks), length(ls))
+    nτ = length(τs)
+
+    ws = similar(τs) # precompute trapezoidal rule weights
+    ws[1] = 0.5 * (τs[2] - τs[1])
+    @inbounds for iτ in 2:nτ-1
+        ws[iτ] = 0.5 * (τs[iτ+1] - τs[iτ-1])
+    end
+    ws[nτ] = 0.5 * (τs[nτ] - τs[nτ-1])
+
+    Is = similar(Ss, length(ks), length(jl.l))
+    nl = length(jl.l)
+    il_limber = searchsortedfirst(jl.l, l_limber) # First il index with l ≥ l_limber (=nl+1 when l_limber = typemax, i.e. no Limber modes)
 
     verbose && l_limber < typemax(Int) && println("Using Limber approximation for l ≥ $l_limber")
 
-    # TODO: skip and set jl to zero if l ≳ kτ0 or another cutoff?
-    @fastmath @inbounds @tasks for il in eachindex(ls) # parallellize independent loop iterations
+    # Loop order k → τ → l to get SIMD on the innermost l-loop
+    @fastmath @inbounds @tasks for ik in eachindex(ks)
         @set scheduler = thread ? :dynamic : :serial
-        l = ls[il]
-        verbose && print("\rLOS integrating with l = $l")
-        for ik in eachindex(ks)
-            k = ks[ik]
-            I = zero(T)
-            if l ≥ l_limber
-                χ = (l+1/2) / k
-                if χ ≤ χs[1] # otherwise χ > χini > χrec and source function is definitely zero
-                    # cubic Hermite interpolation between two closest points
-                    i₋ = searchsortedfirst(τs, τ0 - χ) # highest index
-                    χ₋ = χs[i₋]
-                    S₋ = Ss[i₋, ik]
-                    if i₋ == 1
-                        S = S₋
-                    else
-                        i₊ = i₋ - 1 # lowest index; χs is sorted in descending order, so χ₋ < χ < χ₊
-                        χ₊ = χs[i₊]
-                        S₊ = Ss[i₊, ik]
-                        Δχ = χ₊ - χ₋
-                        S′₋ = i₋ ≤ length(τs)-1 ? (Ss[i₋+1, ik] - S₊) / (χs[i₋+1] - χ₊) : (S₊ - S₋) / Δχ
-                        S′₊ = i₊ ≥ 2            ? (S₋ - Ss[i₋-2, ik]) / (χ₋ - χs[i₋-2]) : (S₊ - S₋) / Δχ
-                        t  = (χ - χ₋) / Δχ
-                        t² = t * t
-                        t³ = t² * t
-                        S  = (2t³-3t²+1)*S₋ + (t³-2t²+t)*Δχ*S′₋ + (-2t³+3t²)*S₊ + (t³-t²)*Δχ*S′₊
-                    end
-                    I = √(π/(2l+1)) * S / k
-                end
-            else
-                prev = Ss[1, ik] * jl(l, k*χs[1]) # set up first point
-                for iτ in 2:length(τs)
-                    kχ = k * χs[iτ]
-                    halfdτ = halfdτs[iτ-1]
-                    _jl = jl(l, kχ)
-                    curr = Ss[iτ, ik] * _jl
-                    I += halfdτ * (curr + prev)
-                    #kχ < l && abs(_jl) < 1e-20 && break # time cut approximation (disabled; unreliable)
-                    prev = curr
+        @local tmp = zeros(T, nl) # l-contiguous storage for integrals (to help SIMD over l)
+        k = ks[ik]
+        verbose && print("\rLOS integrating k-mode $ik / $(length(ks))")
+
+        # Full line-of-sight integrals for l < l_limber
+        fill!(tmp, zero(T))
+        @inbounds for iτ in eachindex(τs)
+            kχ = k * χs[iτ]
+            Sw = ws[iτ] * Ss[iτ, ik]
+            @inbounds @simd for il in 1:il_limber-1
+                tmp[il] += Sw * jl(il, kχ)
+            end
+        end
+
+        # Limber approximation for l ≥ l_limber
+        @inbounds for il in il_limber:nl
+            l = jl.l[il]
+            χ = (l + 1/2) / k
+            if χ ≤ χs[1] # otherwise source is zero before recombination
+                i₋ = searchsortedfirst(τs, τ0 - χ)
+                χ₋ = χs[i₋]
+                S₋ = Ss[i₋, ik]
+                if i₋ == 1
+                    S = S₋
+                else
+                    i₊ = i₋ - 1 # χs is descending, so χ₋ < χ < χ₊
+                    χ₊ = χs[i₊]
+                    S₊ = Ss[i₊, ik]
+                    Δχ = χ₊ - χ₋
+                    S′₋ = i₋ ≤ nτ-1 ? (Ss[i₋+1, ik] - S₊) / (χs[i₋+1] - χ₊) : (S₊ - S₋) / Δχ
+                    S′₊ = i₊ ≥ 2    ? (S₋ - Ss[i₋-2, ik]) / (χ₋ - χs[i₋-2]) : (S₊ - S₋) / Δχ
+                    t = (χ - χ₋) / Δχ
+                    t² = t*t
+                    t³ = t²*t
+                    S = (2t³-3t²+1)*S₋ + (t³-2t²+t)*Δχ*S′₋ + (-2t³+3t²)*S₊ + (t³-t²)*Δχ*S′₊
+                    tmp[il] = √(π/(2l+1)) * S / k
                 end
             end
-            Is[ik, il] = I
-            #k*τ0 < l && maximum(abs.(I)) < 1e-20 && break # multipole cut approximation (disabled; unreliable)
         end
+
+        Is[ik, :] .= tmp
     end
     verbose && println()
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -125,23 +125,26 @@ end
     jl_lin = SphericalBesselCache(ls; dx = 2π/150, hermite = false)
     jl_her = SphericalBesselCache(ls; dx = 2π/15, hermite = true)
     for (jl, atol) in [(jl_lin, 1e-5), (jl_her, 1e-5)]
-        @test_throws BoundsError jl(5, 0.0) # not cached
-        @test_throws BoundsError jl(10, -1.0)
-        @test_throws BoundsError jl(10, jl.x[end] + 1.0)
-        @test isapprox(jl(10, 0.0), SymBoltz.sphericalbesselj(10, 0.0); atol = 1e-16)
-        @test isapprox(jl(10, jl.x[end]), SymBoltz.sphericalbesselj(10, jl.x[end]); atol = 1e-16)
-        @test isapprox(jl(10, 123.456), SymBoltz.sphericalbesselj(10, 123.456); atol)
+        i5 = jl.i[5]
+        i10 = jl.i[10]
+        @test_throws BoundsError jl(i5, 0.0) # not cached
+        @test_throws BoundsError jl(i10, -1.0)
+        @test_throws BoundsError jl(i10, jl.x[end] + 1.0)
+        @test isapprox(jl(i10, 0.0), SymBoltz.sphericalbesselj(10, 0.0); atol = 1e-16)
+        @test isapprox(jl(i10, jl.x[end]), SymBoltz.sphericalbesselj(10, jl.x[end]); atol = 1e-16)
+        @test isapprox(jl(i10, 123.456), SymBoltz.sphericalbesselj(10, 123.456); atol)
 
         xs = range(jl.x[begin], jl.x[end], step=0.001)
-        @test all(isapprox.(jl.(jl.l', xs), SymBoltz.jl.(jl.l', xs); atol))
+        is = eachindex(ls)
+        @test all(isapprox.(jl.(is', xs), SymBoltz.jl.(ls', xs); atol))
 
         xs = range(jl.x[begin], jl.x[end], length=10)
-        t1 = @belapsed $jl.(10, $xs)
-        t2 = @belapsed SymBoltz.sphericalbesselj.(10, $xs)
+        t1 = @belapsed $jl.($i10, $xs)
+        t2 = @belapsed SymBoltz.sphericalbesselj.($i10, $xs)
         @test t1 < t2 # faster
-        @test (@ballocated $jl(10, π)) == 0 # non-allocating
+        @test (@ballocated $jl($i10, π)) == 0 # non-allocating
 
-        j10(x) = jl(10, x)
+        j10(x) = jl(i10, x)
         @test isfinite(ForwardDiff.derivative(j10, π))
     end
 end


### PR DESCRIPTION
```julia
using SymBoltz
τs = range(0.0, 1.0, length = 500)
ks = range(1e0, 1e3, length = 5000)
Ss = rand(length(τs), length(ks))
jl = SphericalBesselCache(2:100)
@time Δs = los_integrate(Ss, jl.l, τs, ks, jl; thread = false)
```
```
Before:   0.540585 seconds (35 allocations: 3.797 MiB)
After:    0.113247 seconds (33 allocations: 3.791 MiB)
```