### PR TITLE
Add integer-rounded Chebyshev interpolation

### DIFF
--- a/src/SymBoltz.jl
+++ b/src/SymBoltz.jl
@@ -54,7 +54,7 @@ export background, perturbations, expandeq
 export solve, solvebg, solvept, remake, issuccess, parameter_updater
 export parameters_Planck18
 export spectrum_primordial, spectrum_matter, spectrum_matter_nonlinear, spectrum_cmb, correlation_function, variance_matter, stddev_matter, los_integrate, source_grid, source_grid_interp, source_grid_adaptive, source_grid_chebyshev, sound_horizon, distance_luminosity, SphericalBesselCache
-export AbstractInterpolator, EquispacedInterpolator, CubicSplineInterpolator, ChebyshevInterpolator, PiecewiseChebyshevInterpolator, order, interpolate
+export AbstractInterpolator, EquispacedInterpolator, CubicSplineInterpolator, ChebyshevInterpolator, ChebyshevIntegerInterpolator, PiecewiseChebyshevInterpolator, order, interpolate
 export express_derivatives
 export lingrid, loggrid, cosgrid, chebgrid, joingrids!, kτ0grid_default
 

--- a/src/observables/fourier.jl
+++ b/src/observables/fourier.jl
@@ -476,6 +476,29 @@ function baryweights(x::AbstractVector)
     return w
 end
 
+struct ChebyshevIntegerInterpolator{T <: Real, F} <: AbstractInterpolator{T}
+    xs::Vector{T}
+    ys::Vector{T}
+    ws::Vector{T}
+    f::F
+end
+
+function ChebyshevIntegerInterpolator(xmin, xmax, order::Integer)
+    xmax > xmin || throw(ArgumentError("Interval $((xmin, xmax)) is not sorted"))
+    order ≥ 1 || throw(ArgumentError("Order must be ≥ 1, got $order"))
+
+    xs = reverse!(chebpoints(order, xmin, xmax)) # start with Chebyshev points
+    xs = round.(xs) # round each point to its nearest integer
+    allunique(xs) || throw(ArgumentError(
+        "Integer-rounded Chebyshev nodes on ($xmin, $xmax) of order $order collide. Reduce the order or widen the interval."
+    ))
+
+    ys = xs
+    ws = baryweights(ys)
+
+    return ChebyshevIntegerInterpolator(xs, ys, ws, identity)
+end
+
 Base.length(interp::AbstractInterpolator) = length(interp.xs)
 order(interp::AbstractInterpolator) = length(interp) - 1
 
@@ -608,4 +631,5 @@ interpolate(x::AbstractVector, y, x′) = interpolate(CubicSplineInterpolator(x)
 Base.show(io::IO, interp::CubicSplineInterpolator) = print(io, "Cubic spline interpolator: domain = $(extrema(interp)), order = $(order(interp))")
 Base.show(io::IO, interp::EquispacedInterpolator) = print(io, "Equispaced polynomial interpolator: domain = $(extrema(interp)), order = $(order(interp))")
 Base.show(io::IO, interp::ChebyshevInterpolator) = print(io, "Chebyshev polynomial interpolator: domain = $(extrema(interp)), order = $(order(interp))")
+Base.show(io::IO, interp::ChebyshevIntegerInterpolator) = print(io, "Integer-rounded Chebyshev interpolator: domain = $(extrema(interp)), order = $(order(interp))")
 Base.show(io::IO, interp::PiecewiseChebyshevInterpolator) = print(io, "Piecewise Chebyshev polynomial interpolator: domain = $(join(extrema.(interp.subgrids), " + ")), order = $(join(order.(interp.subgrids), " + "))")

--- a/src/observables/fourier.jl
+++ b/src/observables/fourier.jl
@@ -466,6 +466,16 @@ function ChebyshevInterpolator(xmin, xmax, order; f = identity, f⁻¹ = nothing
     return ChebyshevInterpolator(xs, ys, ws, f)
 end
 
+# Compute Barycentric interpolation weights wᵢ = 1 / ∏_{j≠i}(xᵢ - xⱼ) for arbitrary points
+# See https://people.maths.ox.ac.uk/trefethen/barycentric.pdf (section 7)
+# TODO: consider exp(sum(log(...))) trick in https://github.com/chebfun/chebfun/blob/master/baryWeights.m
+function baryweights(x::AbstractVector)
+    C = 4 / (maximum(x) - minimum(x)) # capacity: used to keep product close to 1
+    w = [1 / prod(C*(x[i]-x[j]) for j in eachindex(x) if j != i) for i in eachindex(x)]
+    w ./= maximum(abs, w) # normalize so largest weight is 1 for stability
+    return w
+end
+
 Base.length(interp::AbstractInterpolator) = length(interp.xs)
 order(interp::AbstractInterpolator) = length(interp) - 1
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -942,6 +942,7 @@ end
     @test issorted(interp)
     y′ = interpolate(interp, sin.(interp), x′)
     @test isapprox(y′, sin.(x′); atol = 1e-10) # more accurate than cubic splines
+    @test isapprox(interp.ws, SymBoltz.baryweights(interp.xs); atol = 1e-12)
 
     interp = PiecewiseChebyshevInterpolator((0.0, 5.0, 10.0), (10, 20))
     @test issorted(interp)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -571,10 +571,13 @@ end
     Dls = DlsTT # reference from above
     jl_cubic = SphericalBesselCache(range(2, 2500; length = 60))
     jl_cheb = SphericalBesselCache(ChebyshevInterpolator(2, 2500, 60))
+    jl_chebint = SphericalBesselCache(ChebyshevIntegerInterpolator(2, 2500, 60))
     Dls_cubic = spectrum_cmb(:TT, prob, jl_cubic, ls; normalization = :Dl)
     Dls_cheb = spectrum_cmb(:TT, prob, jl_cheb, ls; normalization = :Dl)
+    Dls_chebint = spectrum_cmb(:TT, prob, jl_chebint, ls; normalization = :Dl)
     @test isapprox(Dls_cubic, Dls; rtol = 1e-1)
-    @test isapprox(Dls_cheb, Dls; rtol = 1e-3)
+    @test isapprox(Dls_cheb, Dls; rtol = 1e-4)
+    @test isapprox(Dls_chebint, Dls; rtol = 1e-4)
 
     # Error with bad input
     @test_throws "outside the l-range" spectrum_cmb(:TT, prob, jl, 1:3000; normalization = :Dl)
@@ -949,4 +952,14 @@ end
     y′ = interpolate(interp, sin.(interp), x′)
     @test isapprox(y′[x′ .≤ 5.0], sin.(x′[x′ .≤ 5.0]); atol = 1e-4) # lower order, less accurate
     @test isapprox(y′[x′ .≥ 5.0], sin.(x′[x′ .≥ 5.0]); atol = 1e-12) # higher order, more accurate
+
+    interp = ChebyshevIntegerInterpolator(0, 100, 22)
+    @test issorted(interp.xs)
+    @test all(isinteger, interp.xs)
+    @test allunique(interp.xs)
+    @test extrema(interp) == (0, 100)
+    x′ = range(interp[begin], interp[end]; length = 1000)
+    y′ = interpolate(interp, sin.(π/30 .* interp), x′)
+    @test isapprox(y′, sin.(π/30 .* x′); atol = 1e-10)
+    @test_throws "collide" ChebyshevIntegerInterpolator(0, 100, 23)
 end


### PR DESCRIPTION
To make it possible to interpolate from integer $\ell$. Example:
```julia
using SymBoltz, Plots

M = ΛCDM()
p = parameters_Planck18(M)
prob = CosmologyProblem(M, p)

l = 2:2500
jl1 = SphericalBesselCache(ChebyshevInterpolator(l[begin], l[end], 69))
jl2 = SphericalBesselCache(ChebyshevIntegerInterpolator(l[begin], l[end], 69))
Dl1 = spectrum_cmb(:TT, prob, jl1, l; normalization = :Dl)
Dl2 = spectrum_cmb(:TT, prob, jl2, l; normalization = :Dl)

p1 = plot(l, [Dl1, Dl2]; ylabel = "D(ℓ)", label = ["$(length(jl1.l)) Chebyshev points" "$(length(jl2.l)) integer-rounded Chebyshev points"])
p2 = plot(l, abs.(Dl1 ./ Dl2 .- 1); color = :black, yscale = :log10, ylims = (1e-8, 1e-1), ylabel = "relative error", label = nothing)
p3 = scatter([jl1.l.xs, jl2.l.xs], [jl2.l.xs .- jl2.l.xs, jl1.l.xs .- jl2.l.xs]; ylims = (-0.5, 0.5), marker = :vline, xlabel = "ℓ", label = nothing, ylabel = "dist from true Chebyshev-ℓ")
plot(p1, p2, p3; layout = (3, 1), size = (650, 700), link = :x)
```

<img width="972" height="1050" alt="image" src="https://github.com/user-attachments/assets/7fbcc9fa-30e0-4808-8669-d9b8e83dec0b" />